### PR TITLE
chore: Claude設定にテストコマンドを追加

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -13,7 +13,8 @@
       "Bash(gh pr diff:*)",
       "Bash(docker compose:*)",
       "Bash(docker compose exec:*)",
-      "Bash(docker compose logs:*)"
+      "Bash(docker compose logs:*)",
+      "Bash(bun run test:*)"
     ],
     "deny": [
       "Bash(sudo:*)",


### PR DESCRIPTION
`bun run test:*`をBashコマンド許可リストに追加

- UIコンポーネントのテスト実行のため
- TDD開発フローでの利用を許可