### PR TITLE
feat: [Task 2.2] Goal データ型の実装 (Green Phase)

### DIFF
--- a/types/goal.types.ts
+++ b/types/goal.types.ts
@@ -1,0 +1,53 @@
+/**
+ * Goal データ型定義
+ * Flow Finder アプリケーションのゴール管理で使用される型定義
+ */
+
+/**
+ * ゴールの優先度
+ */
+export enum GoalPriority {
+  LOW = 1,
+  MEDIUM = 2,
+  HIGH = 3,
+  URGENT = 4,
+  CRITICAL = 5
+}
+
+/**
+ * ゴールのステータス
+ */
+export enum GoalStatus {
+  ACTIVE = 'active',
+  COMPLETED = 'completed',
+  PAUSED = 'paused'
+}
+
+/**
+ * ゴールのメインインターフェース
+ */
+export interface Goal {
+  /** ゴールのユニークID（UUID形式） */
+  id: string;
+  
+  /** ゴールのタイトル（必須） */
+  title: string;
+  
+  /** ゴールの詳細説明（任意） */
+  description?: string;
+  
+  /** ゴールの優先度 */
+  priority: GoalPriority;
+  
+  /** ゴールのステータス */
+  status: GoalStatus;
+  
+  /** 作成日時 */
+  created_at: Date;
+  
+  /** 更新日時 */
+  updated_at: Date;
+  
+  /** ユーザーID */
+  user_id: string;
+}


### PR DESCRIPTION
- Goal インターフェース（8プロパティ）を定義
- GoalPriority enum（5段階：LOW=1〜CRITICAL=5）を実装
- GoalStatus enum（3種類：active, completed, paused）を実装
- Task 2.1 で作成したテスト（11/11）が全て成功
- JSDoc による完全なドキュメント付き
- TypeScript コンパイルエラーなし

配置場所: types/goal.types.ts

🤖 Generated with [Claude Code](https://claude.ai/code)