### PR TITLE
fix: ゴール作成フォームの改善とテストの更新

### DIFF
--- a/app/(tabs)/__tests__/goals.test.tsx
+++ b/app/(tabs)/__tests__/goals.test.tsx
@@ -99,8 +99,8 @@ describe("<Goals />", () => {
       fireEvent.press(createButton);
     });
 
-    // ゴール作成フォームが表示されることを確認（保存ボタンの存在で判定）
-    expect(getByText("保存")).toBeTruthy();
+    // ゴール作成フォームが表示されることを確認（作成ボタンの存在で判定）
+    expect(getByText("作成")).toBeTruthy();
   });
 
   test("ゴール作成フォームにタイトル入力フィールドが表示されること", async () => {
@@ -118,7 +118,7 @@ describe("<Goals />", () => {
     });
 
     // タイトル入力フィールドが表示されることを確認
-    expect(getByPlaceholderText("ゴールのタイトルを入力")).toBeTruthy();
+    expect(getByPlaceholderText("例: 英語学習マスター")).toBeTruthy();
   });
 
   test("ゴール作成フォームに優先度選択フィールドが表示されること", async () => {
@@ -153,8 +153,8 @@ describe("<Goals />", () => {
       fireEvent.press(createButton);
     });
 
-    // 保存ボタンが表示されることを確認
-    expect(getByText("保存")).toBeTruthy();
+    // 作成ボタンが表示されることを確認
+    expect(getByText("作成")).toBeTruthy();
   });
 
   test("ゴール作成フォームにキャンセルボタンが表示されること", async () => {
@@ -195,8 +195,8 @@ describe("<Goals />", () => {
       fireEvent.press(cancelButton);
     });
 
-    // ゴール作成フォームが非表示になることを確認（保存ボタンがなくなる）
-    expect(queryByText("保存")).toBeNull();
+    // ゴール作成フォームが非表示になることを確認（作成ボタンがなくなる）
+    expect(queryByText("作成")).toBeNull();
   });
 
   test("既存のゴールアイテムに編集ボタンが表示されること", async () => {

--- a/bun.lock
+++ b/bun.lock
@@ -21,6 +21,8 @@
       },
       "devDependencies": {
         "@babel/core": "^7.25.2",
+        "@react-native-async-storage/async-storage": "^2.2.0",
+        "@testing-library/jest-native": "^5.4.3",
         "@testing-library/react-native": "^13.2.0",
         "@types/jest": "^30.0.0",
         "@types/react": "~18.3.12",
@@ -413,6 +415,8 @@
 
     "@radix-ui/react-slot": ["@radix-ui/react-slot@1.0.1", "", { "dependencies": { "@babel/runtime": "^7.13.10", "@radix-ui/react-compose-refs": "1.0.0" }, "peerDependencies": { "react": "^16.8 || ^17.0 || ^18.0" } }, "sha512-avutXAFL1ehGvAXtPquu0YK5oz6ctS474iM3vNGQIkswrVhdrS52e3uoMQBzZhNRAIE0jBnUyXWNmSjGHhCFcw=="],
 
+    "@react-native-async-storage/async-storage": ["@react-native-async-storage/async-storage@2.2.0", "", { "dependencies": { "merge-options": "^3.0.4" }, "peerDependencies": { "react-native": "^0.0.0-0 || >=0.65 <1.0" } }, "sha512-gvRvjR5JAaUZF8tv2Kcq/Gbt3JHwbKFYfmb445rhOj6NUMx3qPLixmDx5pZAyb9at1bYvJ4/eTUipU5aki45xw=="],
+
     "@react-native-picker/picker": ["@react-native-picker/picker@2.11.1", "", { "peerDependencies": { "react": "*", "react-native": "*" } }, "sha512-ThklnkK4fV3yynnIIRBkxxjxR4IFbdMNJVF6tlLdOJ/zEFUEFUEdXY0KmH0iYzMwY8W4/InWsLiA7AkpAbnexA=="],
 
     "@react-native/assets-registry": ["@react-native/assets-registry@0.76.7", "", {}, "sha512-o79whsqL5fbPTUQO9w1FptRd4cw1TaeOrXtQSLQeDrMVAenw/wmsjyPK10VKtvqxa1KNMtWEyfgxcM8CVZVFmg=="],
@@ -472,6 +476,8 @@
     "@supabase/storage-js": ["@supabase/storage-js@2.7.1", "", { "dependencies": { "@supabase/node-fetch": "^2.6.14" } }, "sha512-asYHcyDR1fKqrMpytAS1zjyEfvxuOIp1CIXX7ji4lHHcJKqyk+sLl/Vxgm4sN6u8zvuUtae9e4kDxQP2qrwWBA=="],
 
     "@supabase/supabase-js": ["@supabase/supabase-js@2.50.5", "", { "dependencies": { "@supabase/auth-js": "2.70.0", "@supabase/functions-js": "2.4.5", "@supabase/node-fetch": "2.6.15", "@supabase/postgrest-js": "1.19.4", "@supabase/realtime-js": "2.11.15", "@supabase/storage-js": "2.7.1" } }, "sha512-FgBFYJ/nsBBN1o4qmQpx1ouupht256FCxNM6r5YTgwGbOVopODzP2xhZPu2ecXdmU4CxTS5/KiGf5j2l3ACozQ=="],
+
+    "@testing-library/jest-native": ["@testing-library/jest-native@5.4.3", "", { "dependencies": { "chalk": "^4.1.2", "jest-diff": "^29.0.1", "jest-matcher-utils": "^29.0.1", "pretty-format": "^29.0.3", "redent": "^3.0.0" }, "peerDependencies": { "react": ">=16.0.0", "react-native": ">=0.59", "react-test-renderer": ">=16.0.0" } }, "sha512-/sSDGaOuE+PJ1Z9Kp4u7PQScSVVXGud59I/qsBFFJvIbcn4P6yYw6cBnBmbPF+X9aRIsTJRDl6gzw5ZkJNm66w=="],
 
     "@testing-library/react-native": ["@testing-library/react-native@13.2.0", "", { "dependencies": { "chalk": "^4.1.2", "jest-matcher-utils": "^29.7.0", "pretty-format": "^29.7.0", "redent": "^3.0.0" }, "peerDependencies": { "jest": ">=29.0.0", "react": ">=18.2.0", "react-native": ">=0.71", "react-test-renderer": ">=18.2.0" }, "optionalPeers": ["jest"] }, "sha512-3FX+vW/JScXkoH8VSCRTYF4KCHC56y4AI6TMDISfLna6r+z8kaSEmxH1I6NVaFOxoWX9yaHDyI26xh7BykmqKw=="],
 
@@ -1099,6 +1105,8 @@
 
     "is-path-inside": ["is-path-inside@3.0.3", "", {}, "sha512-Fd4gABb+ycGAmKou8eMftCupSir5lRxqf4aD/vd0cD2qc4HL07OjCeuHMr8Ro4CoMaeCKDB0/ECBOVWjTwUvPQ=="],
 
+    "is-plain-obj": ["is-plain-obj@2.1.0", "", {}, "sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA=="],
+
     "is-plain-object": ["is-plain-object@2.0.4", "", { "dependencies": { "isobject": "^3.0.1" } }, "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og=="],
 
     "is-potential-custom-element-name": ["is-potential-custom-element-name@1.0.1", "", {}, "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ=="],
@@ -1278,6 +1286,8 @@
     "md5-file": ["md5-file@3.2.3", "", { "dependencies": { "buffer-alloc": "^1.1.0" }, "bin": { "md5-file": "cli.js" } }, "sha512-3Tkp1piAHaworfcCgH0jKbTvj1jWWFgbvh2cXaNCgHwyTCBxxvD1Y04rmfpvdPm1P4oXMOpm6+2H7sr7v9v8Fw=="],
 
     "memoize-one": ["memoize-one@5.2.1", "", {}, "sha512-zYiwtZUcYyXKo/np96AGZAckk+FWWsUdJ3cHGGmld7+AhvcWmQyGCYUh1hc4Q/pkOhb65dQR/pqCyK0cOaHz4Q=="],
+
+    "merge-options": ["merge-options@3.0.4", "", { "dependencies": { "is-plain-obj": "^2.1.0" } }, "sha512-2Sug1+knBjkaMsMgf1ctR1Ujx+Ayku4EdJN4Z+C2+JzoeF7A3OZ9KM2GY0CpQS51NR61LTurMJrRKPhSs3ZRTQ=="],
 
     "merge-stream": ["merge-stream@2.0.0", "", {}, "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w=="],
 

--- a/components/forms/GoalForm.tsx
+++ b/components/forms/GoalForm.tsx
@@ -1,6 +1,5 @@
-import { Picker } from "@react-native-picker/picker";
-import React, { useCallback, useMemo, useState } from "react";
-import { Text, View } from "react-native";
+import React, { useCallback, useState } from "react";
+import { Pressable, Text, TextInput, View } from "react-native";
 import { CreateGoalInput, Goal, GoalPriority } from "../../types/goal.types";
 import { Button } from "../ui/Button";
 import { Input } from "../ui/Input";
@@ -39,11 +38,9 @@ const FORM_CONSTRAINTS = {
  * 優先度選択肢のデータ
  */
 const PRIORITY_OPTIONS = [
-  { label: "低優先度", value: GoalPriority.LOW },
-  { label: "中優先度", value: GoalPriority.MEDIUM },
-  { label: "高優先度", value: GoalPriority.HIGH },
-  { label: "緊急", value: GoalPriority.URGENT },
-  { label: "最重要", value: GoalPriority.CRITICAL },
+  { label: "高", value: GoalPriority.HIGH },
+  { label: "中", value: GoalPriority.MEDIUM },
+  { label: "低", value: GoalPriority.LOW },
 ] as const;
 
 /**
@@ -124,70 +121,93 @@ export const GoalForm: React.FC<GoalFormProps> = React.memo(
       setPriority(value);
     }, []);
 
-    /**
-     * 優先度選択肢のレンダリング
-     */
-    const priorityItems = useMemo(() => {
-      return PRIORITY_OPTIONS.map(({ label, value }) => (
-        <Picker.Item key={value} label={label} value={value} />
-      ));
-    }, []);
-
     return (
-      <View className="bg-white p-6 rounded-lg shadow-lg">
-        <Input
-          label="ゴールタイトル"
-          placeholder="ゴールのタイトルを入力"
-          value={title}
-          onChangeText={setTitle}
-          error={!!errors.title}
-          errorMessage={errors.title}
-          disabled={isSubmitting}
-          accessibilityLabel="ゴールタイトル"
-          accessibilityHint="ゴールのタイトルを入力してください。必須項目です。"
-        />
+      <View className="bg-white flex-1">
+        {/* ヘッダータイトル */}
+        <View className="p-6 pb-0">
+          <Text className="text-lg font-bold text-[#212121] text-center mb-4">
+            {initialGoal ? "ゴール編集" : "新しいゴール"}
+          </Text>
+        </View>
 
-        <Input
-          label="ゴール説明"
-          placeholder="ゴールの詳細説明（任意）"
-          value={description}
-          onChangeText={setDescription}
-          multiline
-          numberOfLines={3}
-          error={!!errors.description}
-          errorMessage={errors.description}
-          disabled={isSubmitting}
-          accessibilityLabel="ゴール説明"
-          accessibilityHint="ゴールの詳細説明を入力してください。任意項目です。"
-        />
+        {/* フォームコンテンツ */}
+        <View className="pb-6 gap-4">
+          {/* タイトル入力 */}
+          <View>
+            <Input
+              label="タイトル"
+              placeholder="例: 英語学習マスター"
+              value={title}
+              onChangeText={setTitle}
+              error={!!errors.title}
+              errorMessage={errors.title}
+              disabled={isSubmitting}
+              accessibilityLabel="ゴールタイトル"
+              accessibilityHint="ゴールのタイトルを入力してください。必須項目です。"
+            />
+          </View>
 
-        <View className="mb-4">
-          <Text className="text-sm font-medium mb-2 text-gray-700">優先度</Text>
-          <View className="border-2 border-[#FFC400] rounded-lg bg-white">
-            <Picker
-              selectedValue={priority}
-              onValueChange={handlePriorityChange}
-              enabled={!isSubmitting}
-              accessibilityLabel="優先度選択"
-              accessibilityHint="ゴールの優先度を選択してください"
-            >
-              {priorityItems}
-            </Picker>
+          {/* 説明入力 */}
+          <View>
+            <Text className="text-sm font-medium mb-2 text-[#212121]">
+              説明（任意）
+            </Text>
+            <TextInput
+              className="border border-gray-300 rounded-lg p-3 bg-white text-sm min-h-[200px]"
+              placeholder="このゴールについて詳しく..."
+              placeholderTextColor="#9CA3AF"
+              value={description}
+              onChangeText={setDescription}
+              multiline
+              numberOfLines={4}
+              textAlignVertical="top"
+              editable={!isSubmitting}
+              accessibilityLabel="ゴール説明"
+              accessibilityHint="ゴールの詳細説明を入力してください。任意項目です。"
+              style={{
+                fontFamily: "System",
+              }}
+            />
+            {errors.description && (
+              <Text className="text-red-500 text-xs mt-1">
+                {errors.description}
+              </Text>
+            )}
+          </View>
+
+          {/* 優先度選択（ボタン形式） */}
+          <View>
+            <Text className="text-sm font-medium mb-2 text-[#212121]">
+              優先度
+            </Text>
+            <View className="flex-row gap-2">
+              {PRIORITY_OPTIONS.map(({ label, value }) => (
+                <Pressable
+                  key={value}
+                  className={`flex-1 py-2 px-3 rounded-lg ${
+                    priority === value ? "bg-[#FFC400]" : "bg-gray-200"
+                  }`}
+                  onPress={() => handlePriorityChange(value)}
+                  disabled={isSubmitting}
+                  accessibilityLabel={`優先度${label}`}
+                  accessibilityRole="button"
+                  accessibilityState={{ selected: priority === value }}
+                >
+                  <Text
+                    className={`text-sm text-center font-medium ${
+                      priority === value ? "text-[#212121]" : "text-[#212121]"
+                    }`}
+                  >
+                    {label}
+                  </Text>
+                </Pressable>
+              ))}
+            </View>
           </View>
         </View>
 
-        <View className="flex-row gap-4 mt-6">
-          <View className="flex-1">
-            <Button
-              variant="primary"
-              onPress={handleSubmit}
-              disabled={isSubmitting}
-              accessibilityLabel={isSubmitting ? "保存中" : "保存"}
-              accessibilityHint="ゴールを保存します"
-            >
-              {isSubmitting ? "保存中..." : "保存"}
-            </Button>
-          </View>
+        {/* アクションボタン */}
+        <View className="flex-row gap-3 pb-6 mt-auto">
           <View className="flex-1">
             <Button
               variant="secondary"
@@ -197,6 +217,17 @@ export const GoalForm: React.FC<GoalFormProps> = React.memo(
               accessibilityHint="ゴールの作成・編集をキャンセルします"
             >
               キャンセル
+            </Button>
+          </View>
+          <View className="flex-1">
+            <Button
+              variant="primary"
+              onPress={handleSubmit}
+              disabled={isSubmitting}
+              accessibilityLabel={isSubmitting ? "保存中" : "作成"}
+              accessibilityHint="ゴールを保存します"
+            >
+              {isSubmitting ? "保存中..." : initialGoal ? "更新" : "作成"}
             </Button>
           </View>
         </View>

--- a/components/forms/__tests__/GoalForm.test.tsx
+++ b/components/forms/__tests__/GoalForm.test.tsx
@@ -20,9 +20,9 @@ describe("GoalForm コンポーネント", () => {
       <GoalForm onSubmit={mockOnSubmit} onCancel={mockOnCancel} />
     );
 
-    expect(getByPlaceholderText("ゴールのタイトルを入力")).toBeTruthy();
-    expect(getByPlaceholderText("ゴールの詳細説明（任意）")).toBeTruthy();
-    expect(getByText("保存")).toBeTruthy();
+    expect(getByPlaceholderText("例: 英語学習マスター")).toBeTruthy();
+    expect(getByPlaceholderText("このゴールについて詳しく...")).toBeTruthy();
+    expect(getByText("作成")).toBeTruthy();
     expect(getByText("キャンセル")).toBeTruthy();
   });
 
@@ -31,7 +31,7 @@ describe("GoalForm コンポーネント", () => {
       <GoalForm onSubmit={mockOnSubmit} onCancel={mockOnCancel} />
     );
 
-    const titleInput = getByPlaceholderText("ゴールのタイトルを入力");
+    const titleInput = getByPlaceholderText("例: 英語学習マスター");
     fireEvent.changeText(titleInput, "英語学習");
 
     expect(titleInput.props.value).toBe("英語学習");
@@ -42,7 +42,7 @@ describe("GoalForm コンポーネント", () => {
       <GoalForm onSubmit={mockOnSubmit} onCancel={mockOnCancel} />
     );
 
-    const descriptionInput = getByPlaceholderText("ゴールの詳細説明（任意）");
+    const descriptionInput = getByPlaceholderText("このゴールについて詳しく...");
     fireEvent.changeText(descriptionInput, "TOEIC 800点を目指す");
 
     expect(descriptionInput.props.value).toBe("TOEIC 800点を目指す");
@@ -53,19 +53,20 @@ describe("GoalForm コンポーネント", () => {
       <GoalForm onSubmit={mockOnSubmit} onCancel={mockOnCancel} />
     );
 
-    const priorityPicker = getByLabelText("優先度選択");
-
-    // Pickerが存在することを確認
-    expect(priorityPicker).toBeTruthy();
-
     // 優先度ラベルが表示されていることを確認
     expect(getByText("優先度")).toBeTruthy();
 
-    // 値を変更してエラーが発生しないことを確認
-    fireEvent(priorityPicker, "valueChange", GoalPriority.HIGH);
+    // 優先度ボタンが表示されていることを確認
+    expect(getByText("高")).toBeTruthy();
+    expect(getByText("中")).toBeTruthy();
+    expect(getByText("低")).toBeTruthy();
 
-    // Pickerの機能が動作することを確認
-    expect(priorityPicker).toBeTruthy();
+    // 高優先度ボタンをクリック
+    const highPriorityButton = getByLabelText("優先度高");
+    fireEvent.press(highPriorityButton);
+
+    // ボタンが動作することを確認
+    expect(highPriorityButton).toBeTruthy();
   });
 
   it("有効なデータで送信が成功すること", () => {
@@ -73,14 +74,14 @@ describe("GoalForm コンポーネント", () => {
       <GoalForm onSubmit={mockOnSubmit} onCancel={mockOnCancel} />
     );
 
-    const titleInput = getByPlaceholderText("ゴールのタイトルを入力");
-    const descriptionInput = getByPlaceholderText("ゴールの詳細説明（任意）");
-    const priorityPicker = getByLabelText("優先度選択");
-    const submitButton = getByText("保存");
+    const titleInput = getByPlaceholderText("例: 英語学習マスター");
+    const descriptionInput = getByPlaceholderText("このゴールについて詳しく...");
+    const highPriorityButton = getByLabelText("優先度高");
+    const submitButton = getByText("作成");
 
     fireEvent.changeText(titleInput, "英語学習");
     fireEvent.changeText(descriptionInput, "TOEIC 800点を目指す");
-    fireEvent(priorityPicker, "valueChange", GoalPriority.HIGH);
+    fireEvent.press(highPriorityButton);
     fireEvent.press(submitButton);
 
     const expectedGoalData: CreateGoalInput = {
@@ -98,7 +99,7 @@ describe("GoalForm コンポーネント", () => {
       <GoalForm onSubmit={mockOnSubmit} onCancel={mockOnCancel} />
     );
 
-    const submitButton = getByText("保存");
+    const submitButton = getByText("作成");
     fireEvent.press(submitButton);
 
     expect(getByText("タイトルは必須です")).toBeTruthy();
@@ -110,9 +111,9 @@ describe("GoalForm コンポーネント", () => {
       <GoalForm onSubmit={mockOnSubmit} onCancel={mockOnCancel} />
     );
 
-    const titleInput = getByPlaceholderText("ゴールのタイトルを入力");
+    const titleInput = getByPlaceholderText("例: 英語学習マスター");
     const longTitle = "あ".repeat(201);
-    const submitButton = getByText("保存");
+    const submitButton = getByText("作成");
 
     fireEvent.changeText(titleInput, longTitle);
     fireEvent.press(submitButton);
@@ -126,10 +127,10 @@ describe("GoalForm コンポーネント", () => {
       <GoalForm onSubmit={mockOnSubmit} onCancel={mockOnCancel} />
     );
 
-    const titleInput = getByPlaceholderText("ゴールのタイトルを入力");
-    const descriptionInput = getByPlaceholderText("ゴールの詳細説明（任意）");
+    const titleInput = getByPlaceholderText("例: 英語学習マスター");
+    const descriptionInput = getByPlaceholderText("このゴールについて詳しく...");
     const longDescription = "あ".repeat(1001);
-    const submitButton = getByText("保存");
+    const submitButton = getByText("作成");
 
     fireEvent.changeText(titleInput, "英語学習");
     fireEvent.changeText(descriptionInput, longDescription);
@@ -163,7 +164,7 @@ describe("GoalForm コンポーネント", () => {
       user_id: "user-id",
     };
 
-    const { getByDisplayValue, getByLabelText, getByText } = render(
+    const { getByDisplayValue, getByText } = render(
       <GoalForm
         onSubmit={mockOnSubmit}
         onCancel={mockOnCancel}
@@ -174,10 +175,11 @@ describe("GoalForm コンポーネント", () => {
     expect(getByDisplayValue("既存のゴール")).toBeTruthy();
     expect(getByDisplayValue("既存の説明")).toBeTruthy();
 
-    const priorityPicker = getByLabelText("優先度選択");
-    expect(priorityPicker).toBeTruthy();
+    // 編集モードのタイトル表示確認
+    expect(getByText("ゴール編集")).toBeTruthy();
     // 優先度選択エリアが表示されていることを確認
     expect(getByText("優先度")).toBeTruthy();
+    expect(getByText("更新")).toBeTruthy();
   });
 
   it("送信中はボタンが無効化されること", () => {
@@ -189,7 +191,7 @@ describe("GoalForm コンポーネント", () => {
       />
     );
 
-    const titleInput = getByPlaceholderText("ゴールのタイトルを入力");
+    const titleInput = getByPlaceholderText("例: 英語学習マスター");
     const submitButton = getByText("保存中...");
 
     fireEvent.changeText(titleInput, "テストゴール");
@@ -205,13 +207,17 @@ describe("GoalForm コンポーネント", () => {
       <GoalForm onSubmit={mockOnSubmit} onCancel={mockOnCancel} />
     );
 
-    // フォームが表示されていることを確認（保存ボタンで判定）
-    const saveButton = getByText("保存");
+    // フォームが表示されていることを確認（作成ボタンで判定）
+    const saveButton = getByText("作成");
     expect(saveButton).toBeTruthy();
     
     // 優先度ラベルでFlow Finderブランドスタイルを確認
     const priorityLabel = getByText("優先度");
     expect(priorityLabel).toBeTruthy();
+    
+    // フォームタイトル確認
+    const formTitle = getByText("新しいゴール");
+    expect(formTitle).toBeTruthy();
   });
 
   it("アクセシビリティ属性が正しく設定されること", () => {

--- a/lib/__tests__/supabase.test.ts
+++ b/lib/__tests__/supabase.test.ts
@@ -12,7 +12,7 @@ jest.mock("@supabase/supabase-js", () => ({
   })),
 }));
 
-// モジュールのモック（デフォルトエクスポート回避）
+// 実際のsupabase.tsファイルの代わりにモックを提供
 jest.mock("../supabase", () => {
   const mockClient = {
     auth: {},

--- a/package.json
+++ b/package.json
@@ -10,9 +10,6 @@
     "test": "jest",
     "test:watch": "jest --watchAll"
   },
-  "jest": {
-    "preset": "jest-expo"
-  },
   "dependencies": {
     "@react-native-picker/picker": "^2.11.1",
     "@supabase/supabase-js": "^2.50.5",
@@ -31,6 +28,8 @@
   },
   "devDependencies": {
     "@babel/core": "^7.25.2",
+    "@react-native-async-storage/async-storage": "^2.2.0",
+    "@testing-library/jest-native": "^5.4.3",
     "@testing-library/react-native": "^13.2.0",
     "@types/jest": "^30.0.0",
     "@types/react": "~18.3.12",

--- a/types/__tests__/goal.types.test.ts
+++ b/types/__tests__/goal.types.test.ts
@@ -74,16 +74,12 @@ describe('Goal データ型', () => {
       expect(GoalPriority.LOW).toBeDefined();
       expect(GoalPriority.MEDIUM).toBeDefined();
       expect(GoalPriority.HIGH).toBeDefined();
-      expect(GoalPriority.URGENT).toBeDefined();
-      expect(GoalPriority.CRITICAL).toBeDefined();
     });
 
     it('優先度値が期待される数値であること', () => {
       expect(GoalPriority.LOW).toBe(1);
       expect(GoalPriority.MEDIUM).toBe(2);
       expect(GoalPriority.HIGH).toBe(3);
-      expect(GoalPriority.URGENT).toBe(4);
-      expect(GoalPriority.CRITICAL).toBe(5);
     });
   });
 
@@ -120,7 +116,7 @@ describe('Goal データ型', () => {
       expect(goal.title.length).toBeGreaterThan(0);
     });
 
-    it('priorityが1-5の範囲内であること', () => {
+    it('priorityが1-3の範囲内であること', () => {
       const goal: Goal = {
         id: 'test-id-123',
         title: 'テストゴール',
@@ -132,7 +128,7 @@ describe('Goal データ型', () => {
       };
 
       expect(goal.priority).toBeGreaterThanOrEqual(1);
-      expect(goal.priority).toBeLessThanOrEqual(5);
+      expect(goal.priority).toBeLessThanOrEqual(3);
     });
 
     it('created_atがupdated_atより前または同じであること', () => {

--- a/types/goal.types.ts
+++ b/types/goal.types.ts
@@ -10,7 +10,7 @@
 /**
  * ゴールの優先度を表すEnum
  * 
- * Flow Finderでは1-5の数値で優先度を管理し、
+ * Flow Finderでは1-3の数値で優先度を管理し、
  * 点検セッションでの優先度判定に使用されます。
  */
 export enum GoalPriority {
@@ -19,11 +19,7 @@ export enum GoalPriority {
   /** 中優先度 - 通常の目標 */
   MEDIUM = 2,
   /** 高優先度 - 重要な目標 */
-  HIGH = 3,
-  /** 緊急 - 近日中に対応が必要 */
-  URGENT = 4,
-  /** 最重要 - 即座に対応が必要 */
-  CRITICAL = 5
+  HIGH = 3
 }
 
 /**


### PR DESCRIPTION
- ゴール作成フォームのボタンラベルを「保存」から「作成」に変更
- 優先度選択をPickerからボタン形式に変更し、選択肢を「高」「中」「低」に簡略化
- テストケースを新しいラベルと優先度選択形式に合わせて更新
- package.jsonとbun.lockに@react-native-async-storage/async-storageと@testing-library/jest-nativeを追加