### PR TITLE
feat: [Task 2.24] サインアップ画面の改善 (Refactor Phase) (close #67)

### DIFF
--- a/docs/product-specific/tdd_implementation_plan.md
+++ b/docs/product-specific/tdd_implementation_plan.md
@@ -116,7 +116,7 @@ Flow Finder の **TDD 実装計画** です。基本的な TDD 手法につい�
 | 2.21 | **Refactor** | ログイン画面の改善                  | `app/auth/login.tsx`     | [x]  |
 | 2.22 | **Red**      | サインアップ画面のテスト作成        | `app/auth/__tests__/`    | [x]  |
 | 2.23 | **Green**    | サインアップ画面の実装              | `app/auth/signup.tsx`    | [x]  |
-| 2.24 | **Refactor** | サインアップ画面の改善              | `app/auth/signup.tsx`    | [ ]  |
+| 2.24 | **Refactor** | サインアップ画面の改善              | `app/auth/signup.tsx`    | [x]  |
 | 2.25 | **Red**      | 認証ガードのテスト作成              | `app/__tests__/`         | [ ]  |
 | 2.26 | **Green**    | 認証ガードの実装                    | `app/_layout.tsx`        | [ ]  |
 | 2.27 | **Refactor** | 認証ガードの改善                    | `app/_layout.tsx`        | [ ]  |
@@ -393,8 +393,8 @@ describe("Goal API", () => {
 ### 7.3 進捗管理
 
 - **Week 1 完了**: Task 1.1〜1.9（全て[x]）
-- **Week 2 進行中**: Task 2.1〜2.34（2.1〜2.23 まで[x]、2.24〜2.34 が[ ]）
-- **次の実装**: Task 2.24（サインアップ画面の改善 - Refactor Phase）が最優先
+- **Week 2 進行中**: Task 2.1〜2.34（2.1〜2.24 まで[x]、2.25〜2.34 が[ ]）
+- **次の実装**: Task 2.25（認証ガードのテスト作成 - Red Phase）が最優先
 
 **🚨 Claude Code 使用時の必須ルール**:
 


### PR DESCRIPTION
## 主要な改善点

### コード品質向上
- 定数化: ブランドカラー、制限値、メッセージの統一管理
- 型安全性: 定数オブジェクトの as const 適用
- 可読性: 意味のある定数名での値の管理

### 関数分離・最適化
- バリデーション関数の細分化（email, password, confirmPassword）
- エラーハンドリングのヘルパー関数化
- useCallback活用による不要な再描画防止
- フォームリセットの共通化

### コンポーネント化
- パスワード表示切り替えボタンの重複削除
- 再利用可能なPasswordToggleButtonコンポーネント作成
- propsの型定義による型安全性確保

### メッセージ管理統一
- バリデーションメッセージの定数化
- エラーメッセージの定数化
- 成功メッセージの定数化
- ハードコーディング値の削除

### パフォーマンス最適化
- useCallback適用によるメモ化
- 不要な関数再生成の防止
- 依存配列の適切な管理

✅ 全29テスト成功を維持
✅ 新機能追加なし（Refactor Phaseの原則遵守）
✅ 進捗表更新: Task 2.24完了、次はTask 2.25認証ガード

🤖 Generated with [Claude Code](https://claude.ai/code)