### PR TITLE
[Task 3.18] ゴール編集モーダルのテスト作成 (Red Phase) (close #145)

### DIFF
--- a/app/modal/__tests__/edit-goal.test.tsx
+++ b/app/modal/__tests__/edit-goal.test.tsx
@@ -1,0 +1,442 @@
+import { act, fireEvent, render, waitFor } from "@testing-library/react-native";
+import { Alert } from "react-native";
+import EditGoal from "../edit-goal";
+import { Goal, GoalPriority, GoalStatus } from "../../../types/goal.types";
+
+// React Native Alert のモック
+jest.spyOn(Alert, 'alert');
+
+// expo-routerのモック
+const mockBack = jest.fn();
+const mockPush = jest.fn();
+jest.mock("expo-router", () => ({
+  router: {
+    back: mockBack,
+    push: mockPush,
+  },
+}));
+
+// useAuthフックのモック
+jest.mock("../../../hooks/useAuth", () => ({
+  useAuth: jest.fn(() => ({
+    isAuthenticated: true,
+    loading: false,
+    user: {
+      id: "mock-user-id",
+      email: "test@example.com",
+      created_at: new Date().toISOString(),
+    },
+    error: null,
+  })),
+}));
+
+// Supabaseクライアントのモック
+jest.mock("../../../lib/supabase", () => ({
+  getSupabaseClient: jest.fn(() => ({
+    from: jest.fn(() => ({
+      update: jest.fn(() => ({
+        eq: jest.fn(() => ({
+          select: jest.fn(() => ({
+            single: jest.fn(() =>
+              Promise.resolve({
+                data: {
+                  id: "mock-goal-id",
+                  title: "更新されたゴール",
+                  description: "更新された説明",
+                  priority: 2,
+                  status: "active",
+                  updated_at: new Date().toISOString(),
+                  user_id: "mock-user-id",
+                },
+                error: null,
+              })
+            ),
+          })),
+        })),
+      })),
+    })),
+  })),
+}));
+
+const mockGoalData: Goal = {
+  id: "mock-goal-id", 
+  title: "英語学習マスター",
+  description: "TOEIC900点を目指して学習を継続する",
+  priority: GoalPriority.HIGH,
+  status: GoalStatus.ACTIVE,
+  created_at: new Date("2024-01-01T00:00:00.000Z"),
+  updated_at: new Date("2024-01-01T00:00:00.000Z"),
+  user_id: "mock-user-id",
+};
+
+// ゴール編集モーダルのテスト（Red Phase）
+describe("<EditGoal />", () => {
+  beforeEach(() => {
+    mockBack.mockClear();
+    mockPush.mockClear();
+  });
+
+  test("モーダルが正しく表示されること", async () => {
+    const { getByTestId } = render(<EditGoal goal={mockGoalData} />);
+
+    // モーダルコンテナが表示されることを確認
+    await waitFor(() => {
+      const modal = getByTestId("edit-goal-modal");
+      expect(modal).toBeTruthy();
+      expect(modal.props.accessibilityRole).toBe("dialog");
+    });
+  });
+
+  test("既存のゴール情報が初期値として表示されること", async () => {
+    const { getByDisplayValue } = render(<EditGoal goal={mockGoalData} />);
+
+    // 既存のゴール情報が初期値として表示されることを確認
+    await waitFor(() => {
+      expect(getByDisplayValue("英語学習マスター")).toBeTruthy();
+      expect(getByDisplayValue("TOEIC900点を目指して学習を継続する")).toBeTruthy();
+    });
+  });
+
+  test("タイトル入力フィールドが表示され、編集可能であること", async () => {
+    const { getByTestId } = render(<EditGoal goal={mockGoalData} />);
+
+    // タイトル入力フィールドが表示され、編集可能であることを確認
+    await waitFor(() => {
+      const titleInput = getByTestId("goal-title-input");
+      expect(titleInput).toBeTruthy();
+      expect(titleInput.props.editable).toBe(true);
+      expect(titleInput.props.value).toBe("英語学習マスター");
+    });
+  });
+
+  test("説明入力フィールドが表示され、編集可能であること", async () => {
+    const { getByTestId } = render(<EditGoal goal={mockGoalData} />);
+
+    // 説明入力フィールドが表示され、編集可能であることを確認
+    await waitFor(() => {
+      const descriptionInput = getByTestId("goal-description-input");
+      expect(descriptionInput).toBeTruthy();
+      expect(descriptionInput.props.editable).toBe(true);
+      expect(descriptionInput.props.value).toBe("TOEIC900点を目指して学習を継続する");
+    });
+  });
+
+  test("優先度セレクターが表示され、現在の優先度が選択されていること", async () => {
+    const { getByTestId } = render(<EditGoal goal={mockGoalData} />);
+
+    // 優先度セレクターが表示され、現在の優先度が選択されていることを確認
+    await waitFor(() => {
+      const priorityHigh = getByTestId("priority-high-button");
+      const priorityMedium = getByTestId("priority-medium-button");
+      const priorityLow = getByTestId("priority-low-button");
+
+      expect(priorityHigh).toBeTruthy();
+      expect(priorityMedium).toBeTruthy();
+      expect(priorityLow).toBeTruthy();
+
+      // 高優先度が選択されていることを確認
+      expect(priorityHigh.props.accessibilityState.selected).toBe(true);
+      expect(priorityMedium.props.accessibilityState.selected).toBe(false);
+      expect(priorityLow.props.accessibilityState.selected).toBe(false);
+    });
+  });
+
+  test("優先度を変更できること", async () => {
+    const { getByTestId } = render(<EditGoal goal={mockGoalData} />);
+
+    await waitFor(() => {
+      expect(getByTestId("priority-medium-button")).toBeTruthy();
+    });
+
+    // 中優先度ボタンをタップ
+    const priorityMediumButton = getByTestId("priority-medium-button");
+    await act(async () => {
+      fireEvent.press(priorityMediumButton);
+    });
+
+    // 中優先度が選択されることを確認
+    await waitFor(() => {
+      expect(priorityMediumButton.props.accessibilityState.selected).toBe(true);
+    });
+  });
+
+  test("保存ボタンが表示され、タップできること", async () => {
+    const { getByTestId } = render(<EditGoal goal={mockGoalData} />);
+
+    // 保存ボタンが表示され、タップできることを確認
+    await waitFor(() => {
+      const saveButton = getByTestId("save-goal-button");
+      expect(saveButton).toBeTruthy();
+      expect(saveButton.props.accessibilityRole).toBe("button");
+      expect(saveButton.props.accessibilityLabel).toBe("ゴールを保存");
+    });
+  });
+
+  test("キャンセルボタンが表示され、タップできること", async () => {
+    const { getByTestId } = render(<EditGoal goal={mockGoalData} />);
+
+    // キャンセルボタンが表示され、タップできることを確認
+    await waitFor(() => {
+      const cancelButton = getByTestId("cancel-button");
+      expect(cancelButton).toBeTruthy();
+      expect(cancelButton.props.accessibilityRole).toBe("button");
+      expect(cancelButton.props.accessibilityLabel).toBe("キャンセル");
+    });
+  });
+
+  test("閉じるボタンが表示され、タップできること", async () => {
+    const { getByTestId } = render(<EditGoal goal={mockGoalData} />);
+
+    // 閉じるボタンが表示され、タップできることを確認
+    await waitFor(() => {
+      const closeButton = getByTestId("close-modal-button");
+      expect(closeButton).toBeTruthy();
+      expect(closeButton.props.accessibilityRole).toBe("button");
+      expect(closeButton.props.accessibilityLabel).toBe("モーダルを閉じる");
+    });
+  });
+
+  test("タイトル入力フィールドの値を変更できること", async () => {
+    const { getByTestId } = render(<EditGoal goal={mockGoalData} />);
+
+    await waitFor(() => {
+      expect(getByTestId("goal-title-input")).toBeTruthy();
+    });
+
+    // タイトルを変更
+    const titleInput = getByTestId("goal-title-input");
+    await act(async () => {
+      fireEvent.changeText(titleInput, "新しいゴールタイトル");
+    });
+
+    // 変更されたタイトルが表示されることを確認
+    await waitFor(() => {
+      expect(titleInput.props.value).toBe("新しいゴールタイトル");
+    });
+  });
+
+  test("説明入力フィールドの値を変更できること", async () => {
+    const { getByTestId } = render(<EditGoal goal={mockGoalData} />);
+
+    await waitFor(() => {
+      expect(getByTestId("goal-description-input")).toBeTruthy();
+    });
+
+    // 説明を変更
+    const descriptionInput = getByTestId("goal-description-input");
+    await act(async () => {
+      fireEvent.changeText(descriptionInput, "新しい説明");
+    });
+
+    // 変更された説明が表示されることを確認
+    await waitFor(() => {
+      expect(descriptionInput.props.value).toBe("新しい説明");
+    });
+  });
+
+  test("バリデーションエラーが表示されること（タイトル必須）", async () => {
+    const { getByTestId } = render(<EditGoal goal={mockGoalData} />);
+
+    await waitFor(() => {
+      expect(getByTestId("goal-title-input")).toBeTruthy();
+      expect(getByTestId("save-goal-button")).toBeTruthy();
+    });
+
+    // タイトルを空にして保存ボタンをタップ
+    const titleInput = getByTestId("goal-title-input");
+    await act(async () => {
+      fireEvent.changeText(titleInput, "");
+    });
+
+    const saveButton = getByTestId("save-goal-button");
+    await act(async () => {
+      fireEvent.press(saveButton);
+    });
+
+    // バリデーションエラーが表示されることを確認
+    await waitFor(() => {
+      const errorMessage = getByTestId("title-error-message");
+      expect(errorMessage).toBeTruthy();
+      expect(errorMessage.props.children).toBe("タイトルは必須です");
+    });
+  });
+
+  test("保存ボタンをタップするとゴールが更新されること", async () => {
+    const { getByTestId } = render(<EditGoal goal={mockGoalData} />);
+
+    await waitFor(() => {
+      expect(getByTestId("goal-title-input")).toBeTruthy();
+      expect(getByTestId("save-goal-button")).toBeTruthy();
+    });
+
+    // タイトルを変更
+    const titleInput = getByTestId("goal-title-input");
+    await act(async () => {
+      fireEvent.changeText(titleInput, "更新されたゴール");
+    });
+
+    // 保存ボタンをタップ
+    const saveButton = getByTestId("save-goal-button");
+    await act(async () => {
+      fireEvent.press(saveButton);
+    });
+
+    // 成功メッセージが表示されることを確認
+    await waitFor(() => {
+      const successMessage = getByTestId("success-message");
+      expect(successMessage).toBeTruthy();
+      expect(successMessage.props.children).toBe("ゴールを更新しました");
+    });
+  });
+
+  test("キャンセルボタンをタップするとモーダルが閉じること", async () => {
+    const { getByTestId } = render(<EditGoal goal={mockGoalData} />);
+
+    await waitFor(() => {
+      expect(getByTestId("cancel-button")).toBeTruthy();
+    });
+
+    // キャンセルボタンをタップ
+    const cancelButton = getByTestId("cancel-button");
+    await act(async () => {
+      fireEvent.press(cancelButton);
+    });
+
+    // モーダルが閉じることを確認
+    expect(mockBack).toHaveBeenCalled();
+  });
+
+  test("閉じるボタンをタップするとモーダルが閉じること", async () => {
+    const { getByTestId } = render(<EditGoal goal={mockGoalData} />);
+
+    await waitFor(() => {
+      expect(getByTestId("close-modal-button")).toBeTruthy();
+    });
+
+    // 閉じるボタンをタップ
+    const closeButton = getByTestId("close-modal-button");
+    await act(async () => {
+      fireEvent.press(closeButton);
+    });
+
+    // モーダルが閉じることを確認
+    expect(mockBack).toHaveBeenCalled();
+  });
+
+  test("Flow Finderブランドカラーが適用されること", async () => {
+    const { getByTestId } = render(<EditGoal goal={mockGoalData} />);
+
+    await waitFor(() => {
+      // primary色（#FFC400）のボタンが存在することを確認
+      const saveButton = getByTestId("save-goal-button");
+      expect(saveButton).toHaveStyle({ backgroundColor: "#FFC400" });
+
+      // secondary色（#212121）のテキストが存在することを確認
+      const modalTitle = getByTestId("modal-title");
+      expect(modalTitle).toHaveStyle({ color: "#212121" });
+    });
+  });
+
+  test("アクセシビリティラベルが適切に設定されていること", async () => {
+    const { getByTestId } = render(<EditGoal goal={mockGoalData} />);
+
+    await waitFor(() => {
+      // モーダル自体のアクセシビリティ
+      const modal = getByTestId("edit-goal-modal");
+      expect(modal.props.accessibilityRole).toBe("dialog");
+      expect(modal.props.accessibilityLabel).toBe("ゴール編集");
+
+      // 各要素のアクセシビリティラベル
+      const titleInput = getByTestId("goal-title-input");
+      expect(titleInput.props.accessibilityLabel).toBe("ゴールタイトル");
+
+      const descriptionInput = getByTestId("goal-description-input");
+      expect(descriptionInput.props.accessibilityLabel).toBe("ゴール説明");
+
+      const saveButton = getByTestId("save-goal-button");
+      expect(saveButton.props.accessibilityLabel).toBe("ゴールを保存");
+
+      const cancelButton = getByTestId("cancel-button");
+      expect(cancelButton.props.accessibilityLabel).toBe("キャンセル");
+    });
+  });
+
+  test("ゴールデータが見つからない場合のエラー表示", async () => {
+    const { getByText } = render(<EditGoal goal={null} />);
+
+    // エラーメッセージが表示されることを確認
+    await waitFor(() => {
+      expect(getByText("ゴールが見つかりません")).toBeTruthy();
+    });
+  });
+
+  test("ローディング中の表示", async () => {
+    const { getByTestId } = render(<EditGoal goal={mockGoalData} isLoading={true} />);
+
+    // ローディングインジケーターが表示されることを確認
+    await waitFor(() => {
+      expect(getByTestId("loading-indicator")).toBeTruthy();
+    });
+  });
+
+  test("モーダルオーバーレイのスタイルが適切に適用されること", async () => {
+    const { getByTestId } = render(<EditGoal goal={mockGoalData} />);
+
+    await waitFor(() => {
+      const modalOverlay = getByTestId("modal-overlay");
+      expect(modalOverlay).toHaveStyle({
+        backgroundColor: "rgba(0, 0, 0, 0.5)",
+        position: "absolute",
+        top: 0,
+        left: 0,
+        right: 0,
+        bottom: 0,
+      });
+    });
+  });
+
+  test("優先度の表示が正しいこと", async () => {
+    // 高優先度
+    const { getByTestId: getByTestIdHigh } = render(<EditGoal goal={mockGoalData} />);
+    await waitFor(() => {
+      const priorityHigh = getByTestIdHigh("priority-high-button");
+      expect(priorityHigh.props.accessibilityState.selected).toBe(true);
+    });
+
+    // 中優先度
+    const mediumGoal = { ...mockGoalData, priority: GoalPriority.MEDIUM };
+    const { getByTestId: getByTestIdMedium } = render(<EditGoal goal={mediumGoal} />);
+    await waitFor(() => {
+      const priorityMedium = getByTestIdMedium("priority-medium-button");
+      expect(priorityMedium.props.accessibilityState.selected).toBe(true);
+    });
+
+    // 低優先度
+    const lowGoal = { ...mockGoalData, priority: GoalPriority.LOW };
+    const { getByTestId: getByTestIdLow } = render(<EditGoal goal={lowGoal} />);
+    await waitFor(() => {
+      const priorityLow = getByTestIdLow("priority-low-button");
+      expect(priorityLow.props.accessibilityState.selected).toBe(true);
+    });
+  });
+
+  test("保存処理中の状態表示", async () => {
+    const { getByTestId } = render(<EditGoal goal={mockGoalData} />);
+
+    await waitFor(() => {
+      expect(getByTestId("save-goal-button")).toBeTruthy();
+    });
+
+    // 保存ボタンをタップ
+    const saveButton = getByTestId("save-goal-button");
+    await act(async () => {
+      fireEvent.press(saveButton);
+    });
+
+    // 保存中の状態が表示されることを確認
+    await waitFor(() => {
+      expect(saveButton.props.accessibilityState.busy).toBe(true);
+      expect(saveButton.props.children).toBe("保存中...");
+    });
+  });
+});

--- a/docs/product-specific/tdd_implementation_plan.md
+++ b/docs/product-specific/tdd_implementation_plan.md
@@ -198,7 +198,7 @@ Flow Finder の **TDD 実装計画** です。基本的な TDD 手法につい�
 | 3.15 | **Red**      | ゴール詳細表示モーダルのテスト作成   | `app/modal/`              | [x]  |
 | 3.16 | **Green**    | ゴール詳細表示モーダルの実装         | `app/modal/goal-detail.tsx` | [x]  |
 | 3.17 | **Refactor** | ゴール詳細表示モーダルの改善         | `app/modal/goal-detail.tsx` | [x]  |
-| 3.18 | **Red**      | ゴール編集モーダルのテスト作成       | `app/modal/`              | [ ]  |
+| 3.18 | **Red**      | ゴール編集モーダルのテスト作成       | `app/modal/`              | [x]  |
 | 3.19 | **Green**    | ゴール編集モーダルの実装             | `app/modal/edit-goal.tsx` | [ ]  |
 | 3.20 | **Refactor** | ゴール編集モーダルの改善             | `app/modal/edit-goal.tsx` | [ ]  |
 | 3.21 | **UI/UX**    | GoalCard達成ボタン追加（画面カタログ仕様） | `components/ui/GoalCard.tsx` | [ ]  |
@@ -612,7 +612,7 @@ describe("Goal API", () => {
   - Week 3 追加実装: Task 3.15〜3.24（必須機能実装）
   - Week 3 品質統一: Task 3.25〜3.29（画面カタログ準拠）
   - Week 3 リリース: Task 3.30〜3.31（App Store/Google Play）
-  - **次の実装**: Task 3.18（ゴール編集モーダルのテスト作成 - Red Phase）が最優先
+  - **次の実装**: Task 3.19（ゴール編集モーダルの実装 - Green Phase）が最優先
 
 - **MVP 2 段目（Week 4-6）**: Task 4.1〜6.10
 


### PR DESCRIPTION
## 概要

Task 3.18のゴール編集モーダルのテスト作成（Red Phase）を実装しました。

## 実装内容

### テストファイル作成
- **ファイル**: `app/modal/__tests__/edit-goal.test.tsx`
- **アプローチ**: TDDのRed Phaseとして、失敗するテストを作成

### テスト項目

#### 基本表示テスト
- モーダルが正しく表示されること
- 既存のゴール情報が初期値として表示されること
- 各UI要素が適切に配置されていること

#### フォーム操作テスト
- タイトル・説明入力フィールドの編集機能
- 優先度セレクターの動作
- 入力値の変更と反映

#### アクション テスト
- 保存・キャンセル・閉じるボタンの機能
- 各ボタンの適切な動作

#### UI/UX テスト
- Flow Finderブランドカラー（#FFC400, #212121）の適用
- アクセシビリティ要素の設定
- 画面カタログ準拠のレイアウト

#### バリデーション テスト
- 必須項目（タイトル）のチェック
- エラーメッセージの表示

#### 状態管理テスト
- ローディング状態の表示
- 保存中の状態表示

### 画面カタログ準拠
- ゴール作成モーダルの構造を参考に編集用に適応
- 既存ゴール情報の初期値設定機能
- 統一されたUI/UXデザイン

### テスト結果（Red Phase）
- ✅ 期待通り全てのテストが失敗
- ✅ `edit-goal.tsx`コンポーネントが存在しないためモジュールエラー
- ✅ Red Phaseの目標達成

## 変更ファイル

- `app/modal/__tests__/edit-goal.test.tsx`: 新規作成
- `docs/product-specific/tdd_implementation_plan.md`: 進捗更新

## 次のステップ

- Task 3.19: ゴール編集モーダルの実装 (Green Phase)
- Task 3.20: ゴール編集モーダルの改善 (Refactor Phase)

## 関連Issue

- Closes #145

🚀 Generated with [Claude Code](https://claude.ai/code)