### PR TITLE
[Task 3.22] ゴール画面タブ切り替え機能実装 (UI/UX Phase) (#153)

### DIFF
--- a/app/(tabs)/goals.tsx
+++ b/app/(tabs)/goals.tsx
@@ -1,5 +1,5 @@
 import { Redirect } from "expo-router";
-import React, { useEffect } from "react";
+import React, { useEffect, useState } from "react";
 import {
   ActivityIndicator,
   Pressable,
@@ -17,14 +17,21 @@ import { MvpNote } from "../../components/goals/MvpNote";
 import { useAuth } from "../../hooks/useAuth";
 import { useGoals } from "../../hooks/useGoals";
 import { getGoalIcon, getPriorityText } from "../../utils/goalHelpers";
+import { GoalStatus } from "../../types/goal.types";
 
 /**
  * ゴール管理画面コンポーネント（段階的復旧中）
  *
  * 安全にゴール管理機能を段階的に復旧しています。
  */
+// タブの種類を定義
+type TabType = 'uncompleted' | 'completed';
+
 export default function Goals() {
   const { isAuthenticated, loading: authLoading, user } = useAuth();
+  
+  // タブ状態管理
+  const [activeTab, setActiveTab] = useState<TabType>('uncompleted');
 
   // useGoalsフックでゴール管理ロジックを取得
   const {
@@ -51,6 +58,15 @@ export default function Goals() {
   useEffect(() => {
     fetchGoals();
   }, [fetchGoals]);
+  
+  // タブに応じてゴールをフィルタリング
+  const filteredGoals = goals.filter(goal => {
+    if (activeTab === 'uncompleted') {
+      return goal.status !== GoalStatus.COMPLETED;
+    } else {
+      return goal.status === GoalStatus.COMPLETED;
+    }
+  });
 
   // 認証状態の初期化中はローディング表示
   if (authLoading) {
@@ -86,10 +102,50 @@ export default function Goals() {
           </Pressable>
         </View>
 
+        {/* タブ切り替え */}
+        <View className="flex-row gap-2 mb-4">
+          <Pressable
+            onPress={() => setActiveTab('uncompleted')}
+            className={`flex-1 py-2 px-3 rounded-lg ${
+              activeTab === 'uncompleted' 
+                ? 'bg-primary' 
+                : 'bg-gray-200'
+            }`}
+            accessibilityRole="button"
+            testID="uncompleted-tab"
+          >
+            <Text className={`text-sm font-semibold text-center ${
+              activeTab === 'uncompleted'
+                ? 'text-secondary'
+                : 'text-secondary'
+            }`}>
+              未達成
+            </Text>
+          </Pressable>
+          <Pressable
+            onPress={() => setActiveTab('completed')}
+            className={`flex-1 py-2 px-3 rounded-lg ${
+              activeTab === 'completed' 
+                ? 'bg-primary' 
+                : 'bg-gray-200'
+            }`}
+            accessibilityRole="button"
+            testID="completed-tab"
+          >
+            <Text className={`text-sm font-semibold text-center ${
+              activeTab === 'completed'
+                ? 'text-secondary'
+                : 'text-secondary'
+            }`}>
+              達成済み
+            </Text>
+          </Pressable>
+        </View>
+
         {/* ゴール一覧 */}
-        {!isLoading && !error && goals.length > 0 && (
+        {!isLoading && !error && filteredGoals.length > 0 && (
           <GoalList
-            goals={goals}
+            goals={filteredGoals}
             onOptionsPress={showGoalOptions}
             getGoalIcon={getGoalIcon}
             getPriorityText={getPriorityText}
@@ -97,6 +153,24 @@ export default function Goals() {
         )}
 
         {/* データなしの場合 */}
+        {!isLoading && !error && filteredGoals.length === 0 && goals.length > 0 && (
+          <View className="flex-1 justify-center items-center py-12">
+            <Text className="text-6xl mb-4">
+              {activeTab === 'uncompleted' ? '🎯' : '🏆'}
+            </Text>
+            <Text className="text-lg font-semibold text-gray-700 mb-2">
+              {activeTab === 'uncompleted' ? '未達成のゴールがありません' : '達成済みのゴールがありません'}
+            </Text>
+            <Text className="text-sm text-gray-500 text-center">
+              {activeTab === 'uncompleted' 
+                ? '新しいゴールを追加して目標を設定しましょう！' 
+                : 'ゴールを達成してここに表示させましょう！'
+              }
+            </Text>
+          </View>
+        )}
+
+        {/* 全体でデータなしの場合 */}
         {!isLoading && !error && goals.length === 0 && <EmptyGoalsMessage />}
 
         {/* MVP1段目注記エリア */}

--- a/docs/product-specific/tdd_implementation_plan.md
+++ b/docs/product-specific/tdd_implementation_plan.md
@@ -202,7 +202,7 @@ Flow Finder の **TDD 実装計画** です。基本的な TDD 手法につい�
 | 3.19 | **Green**    | ゴール編集モーダルの実装             | `app/modal/edit-goal.tsx` | [x]  |
 | 3.20 | **Refactor** | ゴール編集モーダルの改善             | `app/modal/edit-goal.tsx` | [x]  |
 | 3.21 | **UI/UX**    | GoalCard達成ボタン追加（画面カタログ仕様） | `components/ui/GoalCard.tsx` | [x]  |
-| 3.22 | **UI/UX**    | ゴール画面タブ切り替え機能実装       | `app/(tabs)/goals.tsx`    | [ ]  |
+| 3.22 | **UI/UX**    | ゴール画面タブ切り替え機能実装       | `app/(tabs)/goals.tsx`    | [x]  |
 | 3.23 | **UI/UX**    | ゴール作成ボタンをホーム画面に移動   | `app/(tabs)/index.tsx` + `goals.tsx` | [ ]  |
 | 3.24 | **UI/UX**    | ホーム画面の実データ表示（ダミーデータ置き換え） | `components/home/AuthenticatedHomeScreen.tsx` | [ ]  |
 
@@ -612,7 +612,7 @@ describe("Goal API", () => {
   - Week 3 追加実装: Task 3.15〜3.24（必須機能実装）
   - Week 3 品質統一: Task 3.25〜3.29（画面カタログ準拠）
   - Week 3 リリース: Task 3.30〜3.31（App Store/Google Play）
-  - **次の実装**: Task 3.22（ゴール画面タブ切り替え機能実装 - UI/UX Phase）が最優先
+  - **次の実装**: Task 3.23（ゴール作成ボタンをホーム画面に移動 - UI/UX Phase）が最優先
 
 - **MVP 2 段目（Week 4-6）**: Task 4.1〜6.10
 


### PR DESCRIPTION
## 概要

MVP1段目画面カタログ仕様に従い、ゴール管理画面に「未達成」と「達成済み」の切り替えタブ機能を実装しました。

## 変更内容

### 1. タブ切り替えUI実装
- 「未達成」「達成済み」の2つのタブを追加
- アクティブタブ: `bg-primary text-secondary`
- 非アクティブタブ: `bg-gray-200 text-secondary`
- タブレイアウト: `flex-row gap-2 mb-4`

### 2. ゴールフィルタリング機能
- `activeTab`状態管理（'uncompleted' | 'completed'）
- `GoalStatus.COMPLETED`によるフィルタリング
- タブに応じた動的なゴールリスト表示

### 3. 空状態メッセージ
- タブごとの適切なメッセージとアイコン表示
- 未達成: 🎯「新しいゴールを追加して目標を設定しましょう！」
- 達成済み: 🏆「ゴールを達成してここに表示させましょう！」

## 画面カタログ準拠

画面カタログのタブスタイルに完全準拠:
- アクティブ: `bg-primary text-secondary font-semibold py-2 px-3 rounded-lg text-sm text-center`
- 非アクティブ: `bg-gray-200 text-secondary font-semibold py-2 px-3 rounded-lg text-sm text-center`

## テスト計画

- [ ] 「未達成」タブクリックで未完了ゴールのみ表示される
- [ ] 「達成済み」タブクリックで完了済みゴールのみ表示される
- [ ] タブの見た目が画面カタログと一致している
- [ ] 空状態メッセージが適切に表示される

## 関連Issue

Closes #153

🎯 Generated with [Claude Code](https://claude.ai/code)