### PR TITLE
[Task 3.23] ゴール作成ボタンをホーム画面に移動 (UI/UX Phase) (#155)

### DIFF
--- a/app/(tabs)/goals.tsx
+++ b/app/(tabs)/goals.tsx
@@ -90,16 +90,8 @@ export default function Goals() {
       <GoalsHeader />
 
       <ScrollView className="flex-1 p-6">
-        <View className="flex-row justify-between items-center mb-4">
+        <View className="mb-4">
           <Text className="text-lg font-bold text-[#212121]">ゴール管理</Text>
-          <Pressable
-            onPress={() => setShowCreateForm(true)}
-            className="bg-[#FFC400] text-[#212121] text-sm font-semibold py-2 px-3 rounded-lg"
-            accessibilityRole="button"
-            testID="add-goal-button"
-          >
-            <Text className="text-[#212121] font-semibold">+ 追加</Text>
-          </Pressable>
         </View>
 
         {/* タブ切り替え */}

--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -1,16 +1,35 @@
 import { useRouter } from "expo-router";
-import React from "react";
+import React, { useState } from "react";
 import AuthenticatedHomeScreen from "../../components/home/AuthenticatedHomeScreen";
 import ErrorScreen from "../../components/home/ErrorScreen";
 import LoadingScreen from "../../components/home/LoadingScreen";
 import UnauthenticatedHomeScreen from "../../components/home/UnauthenticatedHomeScreen";
+import { GoalForm } from "../../components/forms/GoalForm";
 import { useAuth } from "../../hooks/useAuth";
 import { useHomeData } from "../../hooks/useHomeData";
+import { useGoals } from "../../hooks/useGoals";
+import { View, Text, Modal } from "react-native";
 
 export default function HomeScreen() {
   const router = useRouter();
   const { user, loading, error, isAuthenticated } = useAuth();
   const { goalData, refreshing, onRefresh, fetchGoalCount } = useHomeData();
+  
+  // ゴール作成フォーム表示状態
+  const [showCreateForm, setShowCreateForm] = useState(false);
+  
+  // useGoalsフックでゴール作成機能を取得
+  const { isCreating, createGoal } = useGoals(user, isAuthenticated);
+  
+  // ゴール作成ボタンのハンドラ
+  const handleCreateGoal = () => {
+    setShowCreateForm(true);
+  };
+  
+  // ゴール作成完了・キャンセル時のハンドラ
+  const handleFormClose = () => {
+    setShowCreateForm(false);
+  };
 
   if (loading) {
     return <LoadingScreen />;
@@ -20,14 +39,45 @@ export default function HomeScreen() {
   }
   if (isAuthenticated && user) {
     return (
-      <AuthenticatedHomeScreen
-        goalData={goalData}
-        refreshing={refreshing}
-        onRefresh={onRefresh}
-        fetchGoalCount={fetchGoalCount}
-        router={router}
-        user={user}
-      />
+      <>
+        <AuthenticatedHomeScreen
+          goalData={goalData}
+          refreshing={refreshing}
+          onRefresh={onRefresh}
+          fetchGoalCount={fetchGoalCount}
+          router={router}
+          user={user}
+          onCreateGoal={handleCreateGoal}
+        />
+        
+        {/* ゴール作成モーダル */}
+        <Modal
+          visible={showCreateForm}
+          animationType="slide"
+          presentationStyle="pageSheet"
+          onRequestClose={handleFormClose}
+        >
+          <View className="flex-1 bg-white">
+            <View className="bg-primary p-4">
+              <Text className="text-xl font-bold text-secondary">➕ ゴール作成</Text>
+            </View>
+            <View className="flex-1 p-6">
+              <Text className="text-lg font-bold text-[#212121] mb-4 text-center">
+                新しいゴール
+              </Text>
+              <GoalForm
+                onSubmit={async (goalData) => {
+                  await createGoal(goalData);
+                  handleFormClose();
+                  onRefresh(); // ホーム画面を更新
+                }}
+                onCancel={handleFormClose}
+                isSubmitting={isCreating}
+              />
+            </View>
+          </View>
+        </Modal>
+      </>
     );
   }
   return <UnauthenticatedHomeScreen router={router} />;

--- a/components/home/AuthenticatedHomeScreen.tsx
+++ b/components/home/AuthenticatedHomeScreen.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { RefreshControl, ScrollView, Text, View } from "react-native";
+import { Pressable, RefreshControl, ScrollView, Text, View } from "react-native";
 import { SimpleGoalCompletion } from "../ui/SimpleGoalCompletion";
 
 interface AuthenticatedHomeScreenProps {
@@ -9,6 +9,7 @@ interface AuthenticatedHomeScreenProps {
   fetchGoalCount: () => void;
   router: any;
   user: any;
+  onCreateGoal?: () => void;
 }
 
 const AuthenticatedHomeScreen: React.FC<AuthenticatedHomeScreenProps> = ({
@@ -18,6 +19,7 @@ const AuthenticatedHomeScreen: React.FC<AuthenticatedHomeScreenProps> = ({
   fetchGoalCount,
   router,
   user,
+  onCreateGoal,
 }) => {
   // ユーザー名を取得（メールアドレスから名前部分を抽出、またはデフォルト）
   const getUserDisplayName = () => {
@@ -63,23 +65,56 @@ const AuthenticatedHomeScreen: React.FC<AuthenticatedHomeScreenProps> = ({
             </Text>
           </View>
 
-          {/* 今日のゴールセクション */}
+          {/* 未達成のゴールセクション */}
           <View className="mb-6">
-            <Text
-              className="text-sm font-semibold text-[#212121] mb-2"
-              accessibilityRole="header"
-            >
-              🎯 今日のゴール
-            </Text>
-            <View className="bg-gray-50 rounded-xl p-4">
-              <View className="flex-row items-center justify-between mb-2">
-                <Text className="text-sm font-medium">
-                  💼 英語学習マスター
-                </Text>
-              </View>
-              <Text className="text-xs text-gray-600">
-                優先度: 高
+            <View className="flex-row items-center justify-between mb-2">
+              <Text
+                className="text-sm font-semibold text-[#212121]"
+                accessibilityRole="header"
+              >
+                🎯 未達成のゴール
               </Text>
+              {onCreateGoal && (
+                <Pressable
+                  onPress={onCreateGoal}
+                  className="bg-primary text-secondary font-semibold py-2 px-3 rounded-lg ml-2"
+                  accessibilityRole="button"
+                  accessibilityLabel="ゴールを作成する"
+                  testID="create-goal-button"
+                >
+                  <Text className="text-secondary text-sm font-semibold">＋ ゴール作成</Text>
+                </Pressable>
+              )}
+            </View>
+            <View className="gap-3">
+              {/* 未完了ゴール1 */}
+              <View className="bg-gray-50 rounded-xl p-4 flex-row items-center justify-between mb-2">
+                <View className="flex-1">
+                  <Text className="text-sm font-medium">
+                    💼 英語学習マスター
+                  </Text>
+                  <Text className="text-xs text-gray-600 mt-1">
+                    優先度: 高
+                  </Text>
+                </View>
+                <Pressable className="bg-success text-white text-xs font-bold py-1 px-3 rounded-lg ml-2">
+                  <Text className="text-white text-xs font-bold">達成</Text>
+                </Pressable>
+              </View>
+              {/* 未完了ゴール2 */}
+              <View className="bg-gray-50 rounded-xl p-4 flex-row items-center justify-between mb-2">
+                <View className="flex-1">
+                  <Text className="text-sm font-medium">
+                    🏃 健康的な生活習慣
+                  </Text>
+                  <Text className="text-xs text-gray-600 mt-1">
+                    優先度: 中
+                  </Text>
+                </View>
+                <Pressable className="bg-success text-white text-xs font-bold py-1 px-3 rounded-lg ml-2">
+                  <Text className="text-white text-xs font-bold">達成</Text>
+                </Pressable>
+              </View>
             </View>
           </View>
 

--- a/docs/product-specific/tdd_implementation_plan.md
+++ b/docs/product-specific/tdd_implementation_plan.md
@@ -203,7 +203,7 @@ Flow Finder の **TDD 実装計画** です。基本的な TDD 手法につい�
 | 3.20 | **Refactor** | ゴール編集モーダルの改善             | `app/modal/edit-goal.tsx` | [x]  |
 | 3.21 | **UI/UX**    | GoalCard達成ボタン追加（画面カタログ仕様） | `components/ui/GoalCard.tsx` | [x]  |
 | 3.22 | **UI/UX**    | ゴール画面タブ切り替え機能実装       | `app/(tabs)/goals.tsx`    | [x]  |
-| 3.23 | **UI/UX**    | ゴール作成ボタンをホーム画面に移動   | `app/(tabs)/index.tsx` + `goals.tsx` | [ ]  |
+| 3.23 | **UI/UX**    | ゴール作成ボタンをホーム画面に移動   | `app/(tabs)/index.tsx` + `goals.tsx` | [x]  |
 | 3.24 | **UI/UX**    | ホーム画面の実データ表示（ダミーデータ置き換え） | `components/home/AuthenticatedHomeScreen.tsx` | [ ]  |
 
 #### Week 3 最終: 画面カタログ準拠・品質統一
@@ -612,7 +612,7 @@ describe("Goal API", () => {
   - Week 3 追加実装: Task 3.15〜3.24（必須機能実装）
   - Week 3 品質統一: Task 3.25〜3.29（画面カタログ準拠）
   - Week 3 リリース: Task 3.30〜3.31（App Store/Google Play）
-  - **次の実装**: Task 3.23（ゴール作成ボタンをホーム画面に移動 - UI/UX Phase）が最優先
+  - **次の実装**: Task 3.24（ホーム画面の実データ表示 - UI/UX Phase）が最優先
 
 - **MVP 2 段目（Week 4-6）**: Task 4.1〜6.10
 


### PR DESCRIPTION
## 概要

MVP1段目画面カタログ仕様に従い、ゴール作成ボタンをホーム画面に移動し、ゴール管理画面から削除しました。

## 変更内容

### 1. ホーム画面への機能追加
- **AuthenticatedHomeScreen**: ゴール作成ボタンを「未達成のゴール」セクションに追加
- **index.tsx**: ゴール作成フォームモーダル機能を実装
- useGoalsフックを使用してゴール作成機能を統合

### 2. ゴール管理画面からの機能削除
- **goals.tsx**: ゴール作成ボタンを削除
- タイトルのみを表示するシンプルなレイアウトに変更

### 3. ボタンスタイル
- 画面カタログ準拠: `bg-primary text-secondary font-semibold py-2 px-3 rounded-lg ml-2`
- テキスト: "＋ ゴール作成"

### 4. 機能実装
- **Modal表示**: ゴール作成フォームをモーダルで表示
- **状態管理**: useState使用でモーダル表示状態を管理
- **データ更新**: ゴール作成後にホーム画面をリフレッシュ

## 画面カタログ準拠

ホーム画面の「未達成のゴール」セクション仕様に完全準拠:
- セクションタイトルとボタンの水平配置
- 適切なマージンとスタイル
- ゴール作成フォームモーダル機能

## テスト計画

- [ ] ホーム画面でゴール作成ボタンが表示される
- [ ] ボタンクリックでゴール作成フォームモーダルが表示される
- [ ] ゴール作成後にモーダルが閉じてホーム画面が更新される
- [ ] ゴール管理画面からゴール作成ボタンが削除されている
- [ ] 既存のゴール機能が正常に動作する

## 関連Issue

Closes #155

🎯 Generated with [Claude Code](https://claude.ai/code)