### PR TITLE
[Task 3.24] ホーム画面の実データ表示（ダミーデータ置き換え） (UI/UX Phase)

### DIFF
--- a/components/home/AuthenticatedHomeScreen.tsx
+++ b/components/home/AuthenticatedHomeScreen.tsx
@@ -1,22 +1,27 @@
 import React from "react";
-import { Pressable, RefreshControl, ScrollView, Text, View } from "react-native";
+import { Pressable, RefreshControl, ScrollView, Text, View, ActivityIndicator } from "react-native";
 import { SimpleGoalCompletion } from "../ui/SimpleGoalCompletion";
+import { Goal, GoalStatus, GoalPriority } from "../../types/goal.types";
 
 interface AuthenticatedHomeScreenProps {
-  goalData: any;
+  goals: Goal[];
+  isLoadingGoals: boolean;
+  goalsError: string | null;
   refreshing: boolean;
   onRefresh: () => void;
-  fetchGoalCount: () => void;
+  fetchGoals: () => void;
   router: any;
   user: any;
   onCreateGoal?: () => void;
 }
 
 const AuthenticatedHomeScreen: React.FC<AuthenticatedHomeScreenProps> = ({
-  goalData,
+  goals,
+  isLoadingGoals,
+  goalsError,
   refreshing,
   onRefresh,
-  fetchGoalCount,
+  fetchGoals,
   router,
   user,
   onCreateGoal,
@@ -86,36 +91,87 @@ const AuthenticatedHomeScreen: React.FC<AuthenticatedHomeScreenProps> = ({
                 </Pressable>
               )}
             </View>
-            <View className="gap-3">
-              {/* 未完了ゴール1 */}
-              <View className="bg-gray-50 rounded-xl p-4 flex-row items-center justify-between mb-2">
-                <View className="flex-1">
-                  <Text className="text-sm font-medium">
-                    💼 英語学習マスター
-                  </Text>
-                  <Text className="text-xs text-gray-600 mt-1">
-                    優先度: 高
-                  </Text>
-                </View>
-                <Pressable className="bg-success text-white text-xs font-bold py-1 px-3 rounded-lg ml-2">
-                  <Text className="text-white text-xs font-bold">達成</Text>
+
+            {/* ローディング状態 */}
+            {isLoadingGoals && (
+              <View className="flex-1 justify-center items-center py-8">
+                <ActivityIndicator size="small" color="#FFC400" />
+                <Text className="text-sm text-gray-600 mt-2">ゴールを読み込み中...</Text>
+              </View>
+            )}
+
+            {/* エラー状態 */}
+            {goalsError && !isLoadingGoals && (
+              <View className="bg-red-50 rounded-xl p-4 mb-2">
+                <Text className="text-sm text-red-800 font-medium mb-2">
+                  エラーが発生しました
+                </Text>
+                <Text className="text-xs text-red-600 mb-3">
+                  {goalsError}
+                </Text>
+                <Pressable
+                  onPress={fetchGoals}
+                  className="bg-red-600 text-white py-2 px-3 rounded-lg self-start"
+                  accessibilityRole="button"
+                  accessibilityLabel="再試行"
+                >
+                  <Text className="text-white text-xs font-semibold">再試行</Text>
                 </Pressable>
               </View>
-              {/* 未完了ゴール2 */}
-              <View className="bg-gray-50 rounded-xl p-4 flex-row items-center justify-between mb-2">
-                <View className="flex-1">
-                  <Text className="text-sm font-medium">
-                    🏃 健康的な生活習慣
-                  </Text>
-                  <Text className="text-xs text-gray-600 mt-1">
-                    優先度: 中
-                  </Text>
-                </View>
-                <Pressable className="bg-success text-white text-xs font-bold py-1 px-3 rounded-lg ml-2">
-                  <Text className="text-white text-xs font-bold">達成</Text>
-                </Pressable>
+            )}
+
+            {/* 実際のゴールデータを表示 */}
+            {!isLoadingGoals && !goalsError && (
+              <View className="gap-3">
+                {/* 未達成ゴールが存在しない場合 */}
+                {goals.length === 0 ? (
+                  <View className="bg-gray-50 rounded-xl p-6 items-center">
+                    <Text className="text-4xl mb-2">🎯</Text>
+                    <Text className="text-sm font-medium text-gray-700 mb-1">
+                      まだゴールがありません
+                    </Text>
+                    <Text className="text-xs text-gray-500 text-center">
+                      「＋ ゴール作成」ボタンから{"\n"}最初のゴールを設定してみましょう
+                    </Text>
+                  </View>
+                ) : (
+                  /* 実際のゴールリストを表示 */
+                  goals
+                    .filter(goal => goal.status === GoalStatus.ACTIVE) // アクティブなゴールのみ表示
+                    .map((goal) => (
+                      <View
+                        key={goal.id}
+                        className="bg-gray-50 rounded-xl p-4 flex-row items-center justify-between mb-2"
+                      >
+                        <View className="flex-1">
+                          <Text className="text-sm font-medium">
+                            {goal.title}
+                          </Text>
+                          {goal.description && (
+                            <Text className="text-xs text-gray-500 mt-1">
+                              {goal.description}
+                            </Text>
+                          )}
+                          <Text className="text-xs text-gray-600 mt-1">
+                            優先度: {goal.priority === GoalPriority.HIGH ? '高' : goal.priority === GoalPriority.MEDIUM ? '中' : '低'}
+                          </Text>
+                        </View>
+                        <Pressable 
+                          className="bg-success text-white text-xs font-bold py-1 px-3 rounded-lg ml-2"
+                          onPress={() => {
+                            // MVP2段目でゴール完了機能を実装予定
+                            console.log('ゴール完了:', goal.id);
+                          }}
+                          accessibilityRole="button"
+                          accessibilityLabel={`${goal.title}を達成済みにマーク`}
+                        >
+                          <Text className="text-white text-xs font-bold">達成</Text>
+                        </Pressable>
+                      </View>
+                    ))
+                )}
               </View>
-            </View>
+            )}
           </View>
 
           {/* 簡易ゴール完了機能セクション */}

--- a/docs/product-specific/tdd_implementation_plan.md
+++ b/docs/product-specific/tdd_implementation_plan.md
@@ -204,7 +204,7 @@ Flow Finder の **TDD 実装計画** です。基本的な TDD 手法につい�
 | 3.21 | **UI/UX**    | GoalCard達成ボタン追加（画面カタログ仕様） | `components/ui/GoalCard.tsx` | [x]  |
 | 3.22 | **UI/UX**    | ゴール画面タブ切り替え機能実装       | `app/(tabs)/goals.tsx`    | [x]  |
 | 3.23 | **UI/UX**    | ゴール作成ボタンをホーム画面に移動   | `app/(tabs)/index.tsx` + `goals.tsx` | [x]  |
-| 3.24 | **UI/UX**    | ホーム画面の実データ表示（ダミーデータ置き換え） | `components/home/AuthenticatedHomeScreen.tsx` | [ ]  |
+| 3.24 | **UI/UX**    | ホーム画面の実データ表示（ダミーデータ置き換え） | `components/home/AuthenticatedHomeScreen.tsx` | [x]  |
 
 #### Week 3 最終: 画面カタログ準拠・品質統一
 
@@ -612,7 +612,7 @@ describe("Goal API", () => {
   - Week 3 追加実装: Task 3.15〜3.24（必須機能実装）
   - Week 3 品質統一: Task 3.25〜3.29（画面カタログ準拠）
   - Week 3 リリース: Task 3.30〜3.31（App Store/Google Play）
-  - **次の実装**: Task 3.24（ホーム画面の実データ表示 - UI/UX Phase）が最優先
+  - **次の実装**: Task 3.25（画面カタログとの差分調査・一覧化 - QA Phase）が最優先
 
 - **MVP 2 段目（Week 4-6）**: Task 4.1〜6.10
 


### PR DESCRIPTION
## 概要
Task 3.24の実装：ホーム画面で表示されているダミーデータを実際のSupabaseデータベースから取得したデータに置き換え

## 🚀 実装内容

### 主な変更
- **AuthenticatedHomeScreen.tsx**: useGoalsフックを使用して実際のゴールデータを取得・表示
- **app/(tabs)/index.tsx**: useGoalsフック統合とデータフロー修正
- **型安全性向上**: Goal型を使用してTypeScript対応

### 機能改善
- ✅ **ユーザー名の実データ表示**: 既存のuser.emailベースのロジックを活用
- ✅ **未達成ゴールの実データ表示**: GoalStatus.ACTIVEのゴールのみをフィルタして表示
- ✅ **エラーハンドリング**: データ取得失敗時の適切なエラーメッセージと再試行ボタン
- ✅ **ローディング状態**: データ取得中のActivityIndicator表示
- ✅ **空状態**: ゴールが存在しない場合の案内表示

### UI/UX改善
- 画面カタログ（MVP1段目）仕様に準拠したレイアウト
- ゴール作成ボタンの動作確認
- Pull-to-refresh機能の統合

## 🧪 完了条件確認

- [x] ユーザー名が実際のユーザー情報から取得されて表示される
- [x] 未達成ゴールが実際のデータベースから取得されて表示される  
- [x] ゴール作成ボタンが正常に動作する
- [x] データ取得エラー時の適切なフォールバック表示
- [x] 画面カタログの仕様に準拠したUI/UX

## 📱 変更ファイル
- `components/home/AuthenticatedHomeScreen.tsx`: 実データ表示ロジック実装
- `app/(tabs)/index.tsx`: useGoalsフック統合とデータフロー修正
- `docs/product-specific/tdd_implementation_plan.md`: Task 3.24完了マーク

## 🔄 次のステップ
Task 3.25（画面カタログとの差分調査・一覧化）に進む

🤖 Generated with [Claude Code](https://claude.ai/code)