### PR TITLE
feat: 認証画面のレイアウトとエラーハンドリングの改善

### DIFF
--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -1,9 +1,9 @@
-import { Stack } from "expo-router";
-import { ActivityIndicator, View, Text } from "react-native";
-import { useAuth } from "../hooks/useAuth";
-import "../global.css";
-import React, { useMemo } from "react";
 import { AuthError } from "@supabase/supabase-js";
+import { Stack } from "expo-router";
+import React, { useMemo } from "react";
+import { ActivityIndicator, Text, View } from "react-native";
+import "../global.css";
+import { useAuth } from "../hooks/useAuth";
 
 interface LayoutState {
   loading: boolean;
@@ -23,107 +23,118 @@ interface ErrorScreenProps {
 }
 
 // 認証ローディング画面コンポーネント
-const AuthLoadingScreen: React.FC<LoadingScreenProps> = React.memo(({ testID = "auth-loading" }) => {
-  return (
-    <View 
-      className="flex-1 justify-center items-center bg-white" 
-      testID={testID}
-      accessibilityRole="none"
-      accessibilityLabel="認証状態を確認中です"
-    >
-      <ActivityIndicator 
-        size="large" 
-        color="#FFC400" 
-        accessibilityLabel="読み込み中"
-      />
-      <Text 
-        className="mt-4 text-gray-600 text-center"
-        accessibilityRole="text"
+const AuthLoadingScreen: React.FC<LoadingScreenProps> = React.memo(
+  ({ testID = "auth-loading" }) => {
+    return (
+      <View
+        className="flex-1 justify-center items-center bg-white"
+        testID={testID}
+        accessibilityRole="none"
+        accessibilityLabel="認証状態を確認中です"
       >
-        認証状態を確認中...
-      </Text>
-    </View>
-  );
-});
+        <ActivityIndicator
+          size="large"
+          color="#FFC400"
+          accessibilityLabel="読み込み中"
+        />
+        <Text
+          className="mt-4 text-gray-600 text-center"
+          accessibilityRole="text"
+        >
+          認証状態を確認中...
+        </Text>
+      </View>
+    );
+  }
+);
 
 // エラー画面コンポーネント（将来的な拡張用）
-const AuthErrorScreen: React.FC<ErrorScreenProps> = React.memo(({ error, onRetry, testID = "auth-error" }) => {
-  const errorMessage = useMemo(() => {
-    if (!error) return "不明なエラーが発生しました";
-    return error.message || "認証エラーが発生しました";
-  }, [error]);
+const AuthErrorScreen: React.FC<ErrorScreenProps> = React.memo(
+  ({ error, onRetry, testID = "auth-error" }) => {
+    const errorMessage = useMemo(() => {
+      if (!error) return "不明なエラーが発生しました";
+      return error.message || "認証エラーが発生しました";
+    }, [error]);
 
-  return (
-    <View 
-      className="flex-1 justify-center items-center bg-white px-4" 
-      testID={testID}
-      accessibilityRole="none"
-    >
-      <Text 
-        className="text-red-500 text-center mb-4"
-        accessibilityRole="text"
-        accessibilityLabel={`エラー: ${errorMessage}`}
+    return (
+      <View
+        className="flex-1 justify-center items-center bg-white px-4"
+        testID={testID}
+        accessibilityRole="none"
       >
-        エラー: {errorMessage}
-      </Text>
-      {onRetry && (
-        <Text 
-          className="text-blue-500 text-center"
-          onPress={onRetry}
-          accessibilityRole="button"
-          accessibilityLabel="再試行"
+        <Text
+          className="text-red-500 text-center mb-4"
+          accessibilityRole="text"
+          accessibilityLabel={`エラー: ${errorMessage}`}
         >
-          再試行
+          エラー: {errorMessage}
         </Text>
-      )}
-    </View>
-  );
-});
+        {onRetry && (
+          <Text
+            className="text-blue-500 text-center"
+            onPress={onRetry}
+            accessibilityRole="button"
+            accessibilityLabel="再試行"
+          >
+            再試行
+          </Text>
+        )}
+      </View>
+    );
+  }
+);
 
-AuthLoadingScreen.displayName = 'AuthLoadingScreen';
-AuthErrorScreen.displayName = 'AuthErrorScreen';
+AuthLoadingScreen.displayName = "AuthLoadingScreen";
+AuthErrorScreen.displayName = "AuthErrorScreen";
 
 export default function Layout(): JSX.Element {
   const authState = useAuth() as LayoutState;
   const { loading, isAuthenticated, error } = authState;
 
   // メモ化されたナビゲーションスタック設定
-  const stackScreenOptions = useMemo(() => ({
-    headerShown: false,
-    animation: 'slide_from_right' as const,
-  }), []);
+  const stackScreenOptions = useMemo(
+    () => ({
+      headerShown: false,
+      animation: "slide_from_right" as const,
+    }),
+    []
+  );
 
   // デバッグ: 認証状態をコンソールに出力
   if (__DEV__) {
-    console.log('[Layout Debug] 認証状態:', { loading, isAuthenticated, error: error?.message });
+    console.log("[Layout Debug] 認証状態:", {
+      loading,
+      isAuthenticated,
+      error: error?.message,
+    });
   }
 
   // 常にStackを返し、画面レベルで認証チェックを行う
   return (
-    <Stack 
+    <Stack
       screenOptions={stackScreenOptions}
       initialRouteName={!isAuthenticated ? "auth/login" : "(tabs)"}
     >
-      <Stack.Screen 
-        name="(tabs)" 
+      <Stack.Screen
+        name="(tabs)"
         options={{
           ...stackScreenOptions,
-          title: 'Flow Finder',
-        }} 
+          title: "Flow Finder",
+        }}
       />
-      <Stack.Screen 
-        name="auth/login" 
+      <Stack.Screen
+        name="auth/login"
         options={{
           ...stackScreenOptions,
-          title: 'ログイン',
-        }} 
+          title: "ログイン",
+        }}
       />
-      <Stack.Screen 
-        name="auth/signup" 
+      <Stack.Screen
+        name="auth/signup"
         options={{
           ...stackScreenOptions,
-          title: 'サインアップ',
-        }} 
+          title: "サインアップ",
+        }}
       />
     </Stack>
   );

--- a/app/auth/login.tsx
+++ b/app/auth/login.tsx
@@ -105,22 +105,12 @@ export default function Login() {
           className="text-xl font-bold text-[#212121]"
           accessibilityRole="text"
         >
-          🔐 認証
+          🔐 ログイン
         </Text>
       </View>
 
       <View className="flex-1 p-6 justify-between">
         <View>
-          {/* ロゴ・アプリ名エリア */}
-          <View className="items-center mb-6">
-            <Text
-              className="text-xl font-bold text-[#212121] mb-6 text-center"
-              accessibilityRole="text"
-            >
-              ログイン
-            </Text>
-          </View>
-
           {/* フォームエリア */}
           <View className="gap-4" accessibilityLabel="ログインフォーム">
             {/* メールアドレス入力 */}


### PR DESCRIPTION
- AuthLoadingScreenとAuthErrorScreenのコードを整理し、可読性を向上
- ログイン画面のタイトルを「認証」から「ログイン」に変更
- スタイルの一貫性を保つために、コンポーネントのプロパティを整形